### PR TITLE
feat: Add discord bot mapping from discord_id to github_id

### DIFF
--- a/apps/discord-bot/src/commands/common.ts
+++ b/apps/discord-bot/src/commands/common.ts
@@ -6,7 +6,7 @@ const hardCodeIDMap = {
   vdhieu: '797044001579597846',
 }
 
-export function ReplaceGitHubMentions(
+export function replaceGitHubMentions(
   text: string,
   idMap: Record<string, string> = hardCodeIDMap,
 ): [string, Set<string>] {
@@ -24,7 +24,16 @@ export function ReplaceGitHubMentions(
   ]
 }
 
-export async function GetUsername(
+export function replaceDiscordMentions(
+  text: string,
+  idMap: Record<string, string> = hardCodeIDMap,
+): string {
+  return text.replace(/<@?(\d+)>/g, (match, discordId) => {
+    return "@"+(Object.entries(idMap).find(([_, v]) => v === discordId)?.[0] || match)
+  })
+}
+
+export async function getUsername(
   client: Client,
   user_id: string,
   guild_id?: string,
@@ -57,7 +66,7 @@ export async function processResponseToEmbedFields(
 ): Promise<APIEmbedField[]> {
   const fields: APIEmbedField[] = []
   const maxChunkSize = 800
-  const [lines, discordIDs] = ReplaceGitHubMentions(response)
+  const [lines, discordIDs] = replaceGitHubMentions(response)
   let currentChunk = ''
   let isTable = false
   const idUsernameMap = await mapDiscordUsernameToID(
@@ -95,8 +104,6 @@ export async function processResponseToEmbedFields(
   }
 
   pushField()
-
-  console.log(fields)
 
   return fields.map((field) => ({
     name: '',
@@ -166,7 +173,7 @@ async function mapDiscordUsernameToID(
 
   await Promise.all(
     Array.from(ids).map(async (id) => {
-      const username = await GetUsername(client, id, guildID)
+      const username = await getUsername(client, id, guildID)
       resultMap.set(id, username)
     }),
   )

--- a/apps/discord-bot/src/commands/index.ts
+++ b/apps/discord-bot/src/commands/index.ts
@@ -2,8 +2,9 @@ export { Args } from './args.js'
 export type { Command } from './command.js'
 export { CommandDeferType } from './command.js'
 export {
-  ReplaceGitHubMentions,
-  GetUsername,
+  replaceGitHubMentions,
+  replaceDiscordMentions,
+  getUsername,
   processResponseToEmbedFields,
 } from './common.js'
 export {

--- a/apps/discord-bot/src/services/webhook-service.ts
+++ b/apps/discord-bot/src/services/webhook-service.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import bodyParser from 'body-parser'
 import { Client } from 'discord.js'
 import { Logger } from '../services/index.js'
-import { ReplaceGitHubMentions } from '../commands/index.js'
+import { replaceGitHubMentions } from '../commands/index.js'
 
 interface MessagePayload {
   content?: string
@@ -40,13 +40,13 @@ export class WebhookService {
     const payload: MessagePayload = {}
 
     if (request.message) {
-      payload.content = ReplaceGitHubMentions(request.message)[0]
+      payload.content = replaceGitHubMentions(request.message)[0]
     }
 
     if (request.embed) {
       // Process embed description if it exists
       if (request.embed.description) {
-        request.embed.description = ReplaceGitHubMentions(
+        request.embed.description = replaceGitHubMentions(
           request.embed.description,
         )[0]
       }
@@ -56,7 +56,7 @@ export class WebhookService {
         request.embed.fields = request.embed.fields.map((field) => ({
           ...field,
           value: field.value
-            ? ReplaceGitHubMentions(field.value)[0]
+            ? replaceGitHubMentions(field.value)[0]
             : field.value,
         }))
       }


### PR DESCRIPTION
#### What's this PR do?

- [x] `/ask` add discord_id formatting, map discord_id to github_id before send question to agent
<img width="512" alt="image" src="https://github.com/user-attachments/assets/5e8f10d6-e181-493b-b33e-3ff27625b5d4" />

- [x] `/ask` add `I am` before question to identify question sender
<img width="526" alt="image" src="https://github.com/user-attachments/assets/903f645e-424c-44ee-b1ec-cecd922dfbf6" />

