### PR TITLE
fix: ignore merge PRs from status check

### DIFF
--- a/apps/agent/src/mastra/workflows/github-notify-developer-about-pr-status.ts
+++ b/apps/agent/src/mastra/workflows/github-notify-developer-about-pr-status.ts
@@ -149,6 +149,8 @@ const notifyDeveloperAboutPRStatus = new Workflow({
       execute: async () => {
         const prs = await githubClient.getRepoPRs(GITHUB_REPO, {
           from: formatDate(new Date()),
+          isMerged: false,
+          isOpen: true,
         })
 
         return {


### PR DESCRIPTION
This pull request includes a small but important change to the `apps/agent/src/mastra/workflows/github-notify-developer-about-pr-status.ts` file. The change involves updating the parameters for fetching pull requests from the GitHub repository to ensure only open and non-merged pull requests are retrieved.