### PR TITLE
fix: remove default admin permssion for ask command

### DIFF
--- a/apps/discord-bot/src/commands/metadata.ts
+++ b/apps/discord-bot/src/commands/metadata.ts
@@ -1,7 +1,5 @@
 import {
   ApplicationCommandType,
-  PermissionFlagsBits,
-  PermissionsBitField,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord.js'
 
@@ -19,9 +17,7 @@ export const ChatCommandMetadata: {
     description: Lang.getRef('commandDescs.ask', Language.Default),
     description_localizations: Lang.getRefLocalizationMap('commandDescs.ask'),
     dm_permission: true,
-    default_member_permissions: PermissionsBitField.resolve([
-      PermissionFlagsBits.Administrator,
-    ]).toString(),
+    default_member_permissions: undefined,
     options: [
       {
         ...Args.PROMPT,


### PR DESCRIPTION
#### What's this PR do?

- [x] Remove default admin permission for ask command(required to run `build` and `command:register` to see changes)
<img width="596" alt="image" src="https://github.com/user-attachments/assets/7cc81b02-e14e-4333-b07f-88dac2c7caec" />
