### PR TITLE
chore: add githubId input for discord DB webhook endpoint

### DIFF
--- a/apps/discord-bot/src/commands/common.ts
+++ b/apps/discord-bot/src/commands/common.ts
@@ -26,6 +26,13 @@ export function replaceGitHubMentions(
   ]
 }
 
+export function getDiscordIdFromGitHubId(
+  githubId: string,
+  idMap: Record<string, string> = hardCodeIDMap,
+): string | null {
+  return idMap[githubId] || null
+}
+
 export function replaceDiscordMentions(
   text: string,
   idMap: Record<string, string> = hardCodeIDMap,

--- a/apps/discord-bot/src/commands/index.ts
+++ b/apps/discord-bot/src/commands/index.ts
@@ -6,5 +6,6 @@ export {
   replaceDiscordMentions,
   getUsername,
   processResponseToEmbedFields,
+  getDiscordIdFromGitHubId,
 } from './common.js'
 export { ChatCommandMetadata } from './metadata.js'


### PR DESCRIPTION
#### What's this PR do?

- [x] Add `githubId` input for discord DB webhook endpoint, if userId not provided, will attempt to find the discord ID from the `githubId` input

**Added curl with githubId support**
```
curl -X POST http://localhost:3000/webhook/user -H "Content-Type: application/json" -d '{"githubId": "R-Jim", "message": "Test message to @R-Jim In <#964734967517167616> channel"}'
```

**Error messages**
No discord ID mapping for github ID
```
{"error":"No user found with the provided githubId"}
```

No provided userID or githubID
```
{"error":"Missing required fields: userId or githubId"}
```