### PR TITLE
feat: clear message command

### DIFF
--- a/apps/discord-bot/lang/lang.en-GB.json
+++ b/apps/discord-bot/lang/lang.en-GB.json
@@ -137,6 +137,10 @@
             "value": ["{{QUESTION}}"]
           }
         ]
+      },
+      "cleanResponse": {
+        "title": "🤖 Github agent",
+        "fields": []
       }
     },
     "validationEmbeds": {
@@ -214,7 +218,8 @@
       "info": "info",
       "test": "test",
       "accessKey": "accesskey",
-      "ask": "ask"
+      "ask": "ask",
+      "clean": "clean"
     },
     "userCommands": {
       "viewDateJoined": "View Date Joined"
@@ -225,19 +230,22 @@
     "arguments": {
       "command": "command",
       "option": "option",
-      "promptText": "prompt"
+      "promptText": "prompt",
+      "amount": "amount"
     },
     "commandDescs": {
       "help": "Find help or contact support.",
       "info": "View bot info.",
       "test": "Run the test command.",
-      "ask": "Ask a question to the agent bot."
+      "ask": "Ask a question to the agent bot.",
+      "clean": "Clean messages"
     },
     "argDescs": {
       "helpOption": "Option.",
       "infoOption": "Option.",
       "askCommand": "Ask.",
-      "promptText": "Enter Prompt text."
+      "promptText": "Enter Prompt text.",
+      "amount": "Enter amount messages"
     },
     "fields": {
       "commands": "Commands",

--- a/apps/discord-bot/lang/lang.en-US.json
+++ b/apps/discord-bot/lang/lang.en-US.json
@@ -132,6 +132,10 @@
       "askResponse": {
         "title": "🤖 Github agent",
         "fields": []
+      },
+      "cleanResponse": {
+        "title": "🤖 Github agent",
+        "fields": []
       }
     },
     "validationEmbeds": {
@@ -209,7 +213,8 @@
       "info": "info",
       "test": "test",
       "accessKey": "accesskey",
-      "ask": "ask"
+      "ask": "ask",
+      "clean": "clean"
     },
     "userCommands": {
       "viewDateJoined": "View Date Joined"
@@ -220,19 +225,22 @@
     "arguments": {
       "command": "command",
       "option": "option",
-      "promptText": "prompt"
+      "promptText": "prompt",
+      "amount": "amount"
     },
     "commandDescs": {
       "help": "Find help or contact support.",
       "info": "View bot info.",
       "test": "Run the test command.",
-      "ask": "Ask a question to the agent bot."
+      "ask": "Ask a question to the agent bot.",
+      "clean": "Clean messages"
     },
     "argDescs": {
       "helpOption": "Option.",
       "infoOption": "Option.",
       "askCommand": "Ask.",
-      "promptText": "Enter Prompt text."
+      "promptText": "Enter Prompt text.",
+      "amount": "Enter amount messages"
     },
     "fields": {
       "commands": "Commands",

--- a/apps/discord-bot/src/commands/args.ts
+++ b/apps/discord-bot/src/commands/args.ts
@@ -16,4 +16,12 @@ export class Args {
     ),
     type: ApplicationCommandOptionType.String,
   }
+
+  public static readonly AMOUNT: APIApplicationCommandBasicOption = {
+    name: Lang.getRef('arguments.amount', Language.Default),
+    name_localizations: Lang.getRefLocalizationMap('arguments.amount'),
+    description: Lang.getRef('argDescs.amount', Language.Default),
+    description_localizations: Lang.getRefLocalizationMap('argDescs.amount'),
+    type: ApplicationCommandOptionType.Integer,
+  }
 }

--- a/apps/discord-bot/src/commands/chat/clean-command.ts
+++ b/apps/discord-bot/src/commands/chat/clean-command.ts
@@ -22,17 +22,20 @@ export class CleanCommand implements Command {
       if (!intr.isChatInputCommand()) {
         return
       }
-
-      if (
-        !intr.channel.isDMBased() &&
-        !intr.memberPermissions?.has('Administrator')
-      ) {
-        await InteractionUtils.send(
-          intr,
-          'Must be Administrator for removing messages!',
-          true,
+      // Check if the user has the required permissions
+      if (this.requireClientPerms.length > 0 && !intr.channel.isDMBased()) {
+        const missingPermissions = this.requireClientPerms.filter(
+          (perm) => !intr.memberPermissions.has(perm),
         )
-        return
+
+        if (missingPermissions.length > 0) {
+          await InteractionUtils.send(
+            intr,
+            `Must have ${this.requireClientPerms.join(', ')} permission(s) for removing messages!`,
+            true,
+          )
+          return
+        }
       }
 
       // Get the number of messages to clean from the options

--- a/apps/discord-bot/src/commands/chat/clean-command.ts
+++ b/apps/discord-bot/src/commands/chat/clean-command.ts
@@ -1,0 +1,127 @@
+import { CommandInteraction, Message, PermissionsString } from 'discord.js'
+import { RateLimiter } from 'discord.js-rate-limiter'
+
+import { Language } from '../../models/enum-helpers/language.js'
+import { EventData } from '../../models/internal-models.js'
+import { Lang } from '../../services/lang.js'
+import { Command, CommandDeferType } from '../command.js'
+import { InteractionUtils } from '../../utils/interaction-utils.js'
+import { MessageUtils } from '../../utils/message-utils.js'
+
+export class CleanCommand implements Command {
+  public names = [Lang.getRef('chatCommands.clean', Language.Default)]
+  public cooldown?: RateLimiter
+  public deferType: CommandDeferType = CommandDeferType.HIDDEN
+  public requireClientPerms: PermissionsString[] = ['ManageMessages']
+
+  public async execute(
+    intr: CommandInteraction,
+    data: EventData,
+  ): Promise<void> {
+    try {
+      if (!intr.isChatInputCommand()) {
+        return
+      }
+
+      if (
+        !intr.channel.isDMBased() &&
+        !intr.memberPermissions?.has('Administrator')
+      ) {
+        await InteractionUtils.send(
+          intr,
+          'Must be Administrator for removing messages!',
+          true,
+        )
+        return
+      }
+
+      // Get the number of messages to clean from the options
+      let amount = intr.options.getInteger('amount', true)
+
+      // Validate the amount
+      if (amount < 1 || amount > 100) {
+        await InteractionUtils.send(
+          intr,
+          'Please provide a number between 1 and 100.',
+          true,
+        )
+        return
+      }
+
+      // Start with an empty response message
+      await InteractionUtils.send(
+        intr,
+        Lang.getEmbed('displayEmbeds.cleanResponse', data.lang, {
+          RESPONSE: '...',
+          USER: intr.user.id,
+        }).addFields([
+          {
+            name: '',
+            value: 'Checking the messages...',
+          },
+        ]),
+        true,
+      )
+
+      const channelMsgs = await intr.channel.messages.fetch({ limit: amount })
+
+      if (channelMsgs.size < amount) {
+        amount = channelMsgs.size
+      }
+
+      const messagesToDelete: Message[] = []
+
+      channelMsgs.forEach((msg) => {
+        if (
+          msg.author.id === intr.applicationId &&
+          messagesToDelete.length < amount &&
+          msg.deletable
+        ) {
+          messagesToDelete.push(msg)
+        }
+      })
+
+      let msg = 'There is no messages to delete!'
+
+      if (messagesToDelete.length) {
+        // Delete messages
+        if (intr.channel?.isDMBased()) {
+          // In DMs, we need to delete messages one by one
+          for (const message of messagesToDelete) {
+            await MessageUtils.delete(message)
+          }
+        } else {
+          // In guild channels, we can use bulk delete
+          await intr.channel.bulkDelete(messagesToDelete, true)
+        }
+
+        msg = `Successfully deleted ${messagesToDelete.length} messages.`
+      }
+
+      await InteractionUtils.editReply(
+        intr,
+        Lang.getEmbed('displayEmbeds.cleanResponse', data.lang, {
+          USER: intr.user.id,
+        })
+          .setColor(5737479)
+          .addFields([
+            {
+              name: '',
+              value: msg,
+            },
+          ]),
+      )
+    } catch (error) {
+      console.error('Error cleaning messages:', error)
+      await InteractionUtils.send(
+        intr,
+        Lang.getEmbed('errorEmbeds.command', data.lang, {
+          ERROR_CODE: intr.id,
+          GUILD_ID: intr.guild?.id ?? Lang.getRef('other.na', data.lang),
+          SHARD_ID: (intr.guild?.shardId ?? 0).toString(),
+        }),
+        true,
+      )
+    }
+  }
+}

--- a/apps/discord-bot/src/commands/chat/index.ts
+++ b/apps/discord-bot/src/commands/chat/index.ts
@@ -1,1 +1,2 @@
 export { AskCommand } from './ask-command.js'
+export { CleanCommand } from './clean-command.js'

--- a/apps/discord-bot/src/commands/metadata.ts
+++ b/apps/discord-bot/src/commands/metadata.ts
@@ -1,5 +1,7 @@
 import {
   ApplicationCommandType,
+  PermissionFlagsBits,
+  PermissionsBitField,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord.js'
 
@@ -21,6 +23,23 @@ export const ChatCommandMetadata: {
     options: [
       {
         ...Args.PROMPT,
+        required: true,
+      },
+    ],
+  },
+  CLEAN: {
+    type: ApplicationCommandType.ChatInput,
+    name: Lang.getRef('chatCommands.clean', Language.Default),
+    name_localizations: Lang.getRefLocalizationMap('chatCommands.clean'),
+    description: Lang.getRef('commandDescs.clean', Language.Default),
+    description_localizations: Lang.getRefLocalizationMap('commandDescs.clean'),
+    dm_permission: true,
+    default_member_permissions: PermissionsBitField.resolve([
+      PermissionFlagsBits.Administrator,
+    ]).toString(),
+    options: [
+      {
+        ...Args.AMOUNT,
         required: true,
       },
     ],

--- a/apps/discord-bot/src/start-bot.ts
+++ b/apps/discord-bot/src/start-bot.ts
@@ -2,7 +2,7 @@ import { REST } from '@discordjs/rest'
 import { Options, Partials } from 'discord.js'
 import { createRequire } from 'node:module'
 
-import { AskCommand } from './commands/chat/index.js'
+import { AskCommand, CleanCommand } from './commands/chat/index.js'
 import { ChatCommandMetadata, Command } from './commands/index.js'
 import { CommandHandler } from './events/index.js'
 import { CustomClient } from './extensions/index.js'
@@ -40,6 +40,7 @@ async function start(): Promise<void> {
   const commands: Command[] = [
     // Chat Commands
     new AskCommand(),
+    new CleanCommand(),
   ]
 
   // Event handlers


### PR DESCRIPTION
#### What's this PR do?

- [x] Add `/clean` command for clearing message

#### What are the relevant Git tickets?

- https://www.notion.so/dwarves/clean-command-to-clear-messages-1c764b29b84c8070ad40d2200844542e?pvs=4

#### Any background context you want to provide? (if appropriate)

A new `/clean` command that allows administrators to delete a specified number of bot messages (1-100) from a channel. The command:
- Requires Administrator permissions in servers (works in DMs without permission)
- Only deletes messages sent by the bot itself
- Shows progress and results in an ephemeral embed message
- Handles both DM and server channels differently (individual vs bulk deletion)

