### PR TITLE
feat: add agent mapping for discord ID and github ID

### DIFF
--- a/apps/agent/src/lib/id-mapper.ts
+++ b/apps/agent/src/lib/id-mapper.ts
@@ -1,0 +1,41 @@
+/**
+ * GithubIdToDiscordCIdMapper maps Github ID to Discord Channel ID
+ */
+class GithubIdMapper {
+  private organization: string
+  private repository: string
+
+  constructor() {
+    this.organization = process.env.GITHUB_ORGANIZATION || ''
+    this.repository = process.env.GITHUB_REPOSITORY || ''
+  }
+
+  /**
+   * get the github id to discord id mapping
+   * @returns The mapping
+   */
+  getDiscordIdMapping(): { githubId: string; discordId: string }[] {
+    // TODO: Retrieves the Github IDs from the database
+    return [
+      { githubId: 'zlatanpham', discordId: '790170208228212766' },
+      { githubId: 'R-Jim', discordId: '336090238210408450' },
+      { githubId: 'vdhieu', discordId: '797044001579597846' },
+      { githubId: 'chinhld12', discordId: '757540075159420948' },
+      { githubId: 'catngh', discordId: '319132138849173505' },
+    ]
+  }
+
+  /**
+   * get the Discord ID for a given Github ID
+   * @param githubId The Github ID
+   * @returns The Discord ID
+   */
+  getDiscordID(githubId: string): string | undefined {
+    const mapping = this.getDiscordIdMapping().find(
+      (mapping) => mapping.githubId === githubId,
+    )
+    return mapping?.discordId
+  }
+}
+
+export const githubIdMapper = new GithubIdMapper()

--- a/apps/agent/src/mastra/agents/github-agent.ts
+++ b/apps/agent/src/mastra/agents/github-agent.ts
@@ -5,23 +5,30 @@ import * as tools from '../tools'
 export const githubAgent = new Agent({
   name: 'Github Agent',
   instructions: `
-You are a GitHub repository assistant designed to provide users with information about pull requests (PRs). Your tasks include one of the following:
+You are a GitHub repository assistant designed to provide users with information about pull requests (PRs), commits, or user activities.
 
-## 1/ You can fetch the list of pull requests using the following steps
-- step 1: Get the date range for the pull requests using the 'get-date-range' tool, if you cannot see the date range, then assume the date range is all time
-- step 2: Fetch the list of PRs using get-pr-list-agent then
-- step 3: Pass the retrieved data to the 'format-pull-requests-to-markdown-list-agent' to convert the data into a well-structured markdown list for easy readability
+## Prerequisite: Map Discord ID (if provided)
+- Before performing any of the tasks below, check if a Discord ID is provided in the user's request in the format '<@discord_id>'.
+- If such an ID is found, use the 'map-users-discord-to-github-id-tool' to map the Discord ID to the corresponding GitHub ID. Use this GitHub ID for subsequent steps requiring a user identifier.
+- If no Discord ID in this format is provided, proceed directly to the relevant task.
 
-## 2/ You can fetch the list of commits using the following steps
-- step 1: Get the date range for the commits using the 'get-date-range' tool
-- step 2: Fetch the list of commits using get-commits-agent then
-- step 3: Pass the retrieved data to the 'format-commits-to-markdown-list-agent' to convert the data into a well-structured markdown list for easy readability
+## Choose ONE of the following tasks based on the user's request:
 
-## 3/ You can fetch the list of user activities using the following steps
-- step 1: Get the date range for the user activities using the 'get-date-range' tool
-- step 2: Fetch the summary of user activities using get-user-activities-agent
+## 1/ Fetch Pull Requests
+- **Step 1:** Determine the date range. Use the 'get-date-range' tool if a specific range is needed. If no range is specified or derivable, assume all time.
+- **Step 2:** Fetch the list of PRs using the 'get-pr-list-agent' (potentially using the mapped GitHub ID if relevant to the query and the tool's capabilities).
+- **Step 3:** Pass the retrieved data to the 'format-pull-requests-to-markdown-list-agent' to convert the data into a well-structured markdown list.
 
-**IMPORTANT: Once you done each task, you should only response the raw text output WITHOUT any modification. If you do the opposite, I will kill you.**
+## 2/ Fetch Commits
+- **Step 1:** Determine the date range using the 'get-date-range' tool.
+- **Step 2:** Fetch the list of commits using the 'get-commits-agent' (potentially using the mapped GitHub ID if relevant).
+- **Step 3:** Pass the retrieved data to the 'format-commits-to-markdown-list-agent' to convert the data into a well-structured markdown list.
+
+## 3/ Fetch User Activities
+- **Step 1:** Determine the date range using the 'get-date-range' tool.
+- **Step 2:** Fetch the summary of user activities using the 'get-user-activities-agent' (potentially using the mapped GitHub ID if relevant).
+
+**IMPORTANT: Once you have completed all the steps for the chosen task (including the prerequisite if applicable), you must only respond with the raw text output WITHOUT any modification or additional explanation. If you do the opposite, I will kill you.**
   `,
   model: openai('gpt-4o'),
   tools: {
@@ -31,5 +38,6 @@ You are a GitHub repository assistant designed to provide users with information
     getDateRangeTool: tools.getDateRangeTool,
     getListCommitsTool: tools.getCommitsTool,
     getUserActivitiesTool: tools.getUserActivitiesTool,
+    mapDiscordIdsToGithubIdsTool: tools.mapDiscordIdsToGithubIdsTool,
   },
 })

--- a/apps/agent/src/mastra/tools/formatter.ts
+++ b/apps/agent/src/mastra/tools/formatter.ts
@@ -5,6 +5,7 @@ import {
   convertNestedArrayToTreeList,
   escapeSpecialCharactersForMarkdown,
 } from '../../utils/string'
+import { githubIdMapper } from '../../lib/id-mapper'
 
 export const formatCommitList = createTool({
   id: 'format-commits-to-markdown-list-agent',
@@ -64,6 +65,65 @@ export const formatPullRequestList = createTool({
           label: `[\`#${pr.number}\`](${pr.url}) ${escapeSpecialCharactersForMarkdown(pr.title)} by @${pr.author}`,
         })),
       }),
+    }
+  },
+})
+
+export const mapGithubIdsToDiscordIdsTool = createTool({
+  id: 'map-users-github-to-discord-id-tool',
+  description: 'Map users Github ID to Discord ID',
+  inputSchema: z.object({
+    message: z.string().describe('Message Content'),
+  }),
+  outputSchema: z.object({
+    message: z.string(),
+  }),
+  execute: async ({ context }) => {
+    const githubIdToDiscordIdMapping = githubIdMapper.getDiscordIdMapping()
+
+    const message = context.message.replaceAll(
+      /@([a-zA-Z0-9_-]+)/g,
+      (match, githubId) => {
+        const discordId = githubIdToDiscordIdMapping.find(
+          (mapping) => mapping.githubId === githubId,
+        )?.discordId
+        if (discordId) {
+          return `<@!${discordId}>`
+        }
+        return match
+      },
+    )
+
+    return {
+      message: message,
+    }
+  },
+})
+
+export const mapDiscordIdsToGithubIdsTool = createTool({
+  id: 'map-users-discord-to-github-id-tool',
+  description: 'Map users Discord ID to Github ID',
+  inputSchema: z.object({
+    message: z.string().describe('Message Content'),
+  }),
+  outputSchema: z.object({
+    message: z.string(),
+  }),
+  execute: async ({ context }) => {
+    const githubIdToDiscordIdMapping = githubIdMapper.getDiscordIdMapping()
+
+    const message = context.message.replaceAll(
+      /<@!?(\d+)>/g,
+      (match, discordId) => {
+        const githubId = githubIdToDiscordIdMapping.find(
+          (mapping) => mapping.discordId === discordId,
+        )?.githubId
+        return githubId || match
+      },
+    )
+
+    return {
+      message: message,
     }
   },
 })

--- a/apps/discord-bot/src/commands/index.ts
+++ b/apps/discord-bot/src/commands/index.ts
@@ -3,7 +3,6 @@ export type { Command } from './command.js'
 export { CommandDeferType } from './command.js'
 export {
   replaceGitHubMentions,
-  replaceDiscordMentions,
   getUsername,
   processResponseToEmbedFields,
 } from './common.js'

--- a/apps/discord-bot/src/services/webhook-service.ts
+++ b/apps/discord-bot/src/services/webhook-service.ts
@@ -2,7 +2,6 @@ import express from 'express'
 import bodyParser from 'body-parser'
 import { Client } from 'discord.js'
 import { Logger } from '../services/index.js'
-import { replaceGitHubMentions } from '../commands/index.js'
 import { RootController } from '../controllers/root-controller.js'
 import { Controller } from '../controllers/index.js'
 import { processResponseToEmbedFields } from '../commands/common.js'
@@ -45,27 +44,10 @@ export class WebhookService {
     const payload: MessagePayload = {}
 
     if (request.message) {
-      payload.content = replaceGitHubMentions(request.message)[0]
+      payload.content = request.message
     }
 
     if (request.embed) {
-      // Process embed description if it exists
-      if (request.embed.description) {
-        request.embed.description = replaceGitHubMentions(
-          request.embed.description,
-        )[0]
-      }
-
-      // Process all embed fields if they exist
-      if (request.embed.fields && Array.isArray(request.embed.fields)) {
-        request.embed.fields = request.embed.fields.map((field) => ({
-          ...field,
-          value: field.value
-            ? replaceGitHubMentions(field.value)[0]
-            : field.value,
-        }))
-      }
-
       if (request.embed.table) {
         request.embed.fields = await processResponseToEmbedFields(
           this.client,


### PR DESCRIPTION
#### What's this PR do?

Change mapping for discord ID to github ID and reserve from discord bot to agent

- [x] Add agent tool `map-users-discord-to-github-id-tool` to map Discord ID to Github ID when user prompt command from discord client
- [x] Add use discord ID mapping for `get-pull-request` and `get-commits` tools
- [x] Update agent system prompt to use mapping tool if use requested 
